### PR TITLE
feat(FAB): FAB 컴포넌트 구현 및 스토리북 추가

### DIFF
--- a/src/components/Fab/Fab.stories.tsx
+++ b/src/components/Fab/Fab.stories.tsx
@@ -1,0 +1,61 @@
+import { withKnobs } from '@storybook/addon-knobs';
+import Fab from './Fab';
+import Flex from '../Flex';
+
+/**
+ * FAB(Floating Action Button)는 화면에서 기본 또는 가장 일반적인 작업을 수행합니다.
+ * FAB는 일반 및 확장의 두 가지 유형으로 제공됩니다. 확장 타입의 경우, 여러 버튼을 함께 사용할 때 이용되며 'click'이나 'hover' 이벤트 트리거로 버튼을 확장할 수 있습니다.
+ *
+ * 대표적인 예로 BackTop 버튼은 해당 페이지 내 최상단으로 쉽게 돌아갈 수 있는 기능을 제공합니다.
+ */
+
+export default {
+  title: 'Components/FAB',
+  component: Fab,
+  decorators: [withKnobs],
+  parameters: {
+    componentSubtitle: 'FAB(Floating Button Action) 컴포넌트',
+  },
+};
+
+export const Basics = () => {
+  return (
+    // NOTE: 스토리북 상에서는 position='none'으로 하단 고정 안되게 함
+    <Flex gap={30} style={{ position: 'relative' }}>
+      <Fab type='default' position='none' />
+      <Fab type='primary' position='none' />
+    </Flex>
+  );
+};
+
+export const WithTooltip = () => {
+  return (
+    <Flex style={{ height: '80px', padding: '20px', position: 'relative' }}>
+      <Fab color='white' iconName={'menu'} tooltip='Menu' position='none' />
+    </Flex>
+  );
+};
+
+export const ButtonGroups = () => {
+  return (
+    <Fab.Group trigger='none' type='primary' position='none'>
+      <Fab iconName='intro-poll' tooltip='Go to polls' />
+      <Fab iconName='clipboard' tooltip='Copy channel link' />
+      <Fab iconName='fullscreen' tooltip='Fullscreen' />
+      <Fab iconName='disabled' tooltip='Disable participant Q&A' />
+      <Fab iconName='door-back' tooltip='Back to main' />
+    </Fab.Group>
+  );
+};
+
+export const WithButtons = () => {
+  return (
+    <Fab.Group trigger='click' type='primary' position='none'>
+      <Fab iconName='intro-poll' tooltip='Go to polls' />
+      <Fab iconName='clipboard' tooltip='Copy channel link' />
+      <Fab iconName='fullscreen' tooltip='Fullscreen' />
+      <Fab iconName='disabled' tooltip='Disable participant Q&A' />
+      <Fab iconName='door-back' tooltip='Back to main' />
+    </Fab.Group>
+  );
+};

--- a/src/components/Fab/Fab.tsx
+++ b/src/components/Fab/Fab.tsx
@@ -1,0 +1,88 @@
+import { ButtonHTMLAttributes, useState } from 'react';
+import styled from 'styled-components';
+import Icon from '../Icon';
+import FabGroup from './FabGroup';
+import Tooltip from './Tooltip';
+
+export interface Props extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'type'> {
+  type?: FabButtonType;
+  iconName?: string;
+  tooltip?: string;
+}
+
+function Fab({ type = 'circle', iconName = 'round-plus', tooltip, ...rest }: Props) {
+  const [isHovered, setIsHovered] = useState<boolean>(false);
+  const commonButtonProps = {
+    onMouseEnter: () => setIsHovered(true),
+    onMouseLeave: () => setIsHovered(false),
+    children: <Icon name={iconName} size={24} color='white' />,
+    ...rest,
+  };
+
+  return (
+    <FabWrapper>
+      {type === 'icon' ? (
+        <FabIconButton {...commonButtonProps} />
+      ) : (
+        <FabCircleButton {...commonButtonProps} />
+      )}
+      {tooltip && (
+        <Tooltip isShown={isHovered} text={tooltip}>
+          {tooltip}
+        </Tooltip>
+      )}
+    </FabWrapper>
+  );
+}
+
+Fab.Group = FabGroup;
+
+export default Fab;
+
+const FabWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  position: relative;
+  width: fit-content;
+`;
+
+const FabIconButton = styled.button`
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  :hover {
+    svg {
+      [fill] {
+        &:not([fill='none']) {
+          fill: ${({ theme }) => theme.colors.primary2};
+        }
+      }
+
+      [stroke] {
+        &:not([stroke='none']) {
+          stroke: ${({ theme }) => theme.colors.primary2};
+        }
+      }
+    }
+  }
+`;
+
+const FabCircleButton = styled.button`
+  width: 55px;
+  height: 55px;
+  border-radius: 50%;
+  border: none;
+  background-color: ${({ theme }) => theme.colors.primary1};
+  box-shadow: ${({ theme }) => theme.shadow.dropdown};
+  cursor: pointer;
+  z-index: 2;
+
+  :hover,
+  :focus-visible {
+    opacity: 0.7;
+  }
+`;

--- a/src/components/Fab/Fab.tsx
+++ b/src/components/Fab/Fab.tsx
@@ -5,26 +5,44 @@ import FabGroup from './FabGroup';
 import Tooltip from './Tooltip';
 
 export interface Props extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'type'> {
+  shape?: FabButtonShape;
   type?: FabButtonType;
   iconName?: string;
   tooltip?: string;
+  position?: FabPosition;
 }
 
-function Fab({ type = 'circle', iconName = 'round-plus', tooltip, ...rest }: Props) {
+function Fab({
+  shape = 'circle',
+  type = 'default',
+  tooltip,
+  iconName = 'round-plus',
+  position = 'left',
+  ...rest
+}: Props) {
   const [isHovered, setIsHovered] = useState<boolean>(false);
   const commonButtonProps = {
     onMouseEnter: () => setIsHovered(true),
     onMouseLeave: () => setIsHovered(false),
-    children: <Icon name={iconName} size={24} color='white' />,
+    children: (
+      <Icon
+        name={iconName}
+        size={24}
+        color={type === 'primary' || shape === 'icon' ? 'white' : 'titleActive'}
+      />
+    ),
     ...rest,
   };
 
   return (
-    <FabWrapper>
-      {type === 'icon' ? (
+    <FabWrapper position={position}>
+      {shape === 'icon' ? (
         <FabIconButton {...commonButtonProps} />
       ) : (
-        <FabCircleButton {...commonButtonProps} />
+        <FabCircleButton
+          buttonColor={type === 'primary' ? 'primary1' : 'white'}
+          {...commonButtonProps}
+        />
       )}
       {tooltip && (
         <Tooltip isShown={isHovered} text={tooltip}>
@@ -39,11 +57,15 @@ Fab.Group = FabGroup;
 
 export default Fab;
 
-const FabWrapper = styled.div`
+const FabWrapper = styled.div<Pick<Props, 'position'>>`
   display: flex;
   align-items: center;
   position: relative;
   width: fit-content;
+  position: ${({ position }) => position !== 'none' && 'fixed'};
+  left: ${({ position }) => position === 'left' && '2em'};
+  right: ${({ position }) => position === 'right' && '2em'};
+  bottom: ${({ position }) => position !== 'none' && '2em'};
 `;
 
 const FabIconButton = styled.button`
@@ -71,12 +93,12 @@ const FabIconButton = styled.button`
   }
 `;
 
-const FabCircleButton = styled.button`
+const FabCircleButton = styled.button<{ buttonColor: 'primary1' | 'white' }>`
   width: 55px;
   height: 55px;
   border-radius: 50%;
   border: none;
-  background-color: ${({ theme }) => theme.colors.primary1};
+  background-color: ${({ theme, buttonColor }) => theme.colors[buttonColor]};
   box-shadow: ${({ theme }) => theme.shadow.dropdown};
   cursor: pointer;
   z-index: 2;

--- a/src/components/Fab/FabGroup.tsx
+++ b/src/components/Fab/FabGroup.tsx
@@ -1,0 +1,76 @@
+import {
+  Children,
+  ComponentProps,
+  HTMLAttributes,
+  ReactElement,
+  cloneElement,
+  isValidElement,
+  useState,
+} from 'react';
+import Fab from './Fab';
+import styled from 'styled-components';
+
+type FabGroupChild = ReactElement<ComponentProps<typeof Fab>> | null;
+
+export interface Props extends HTMLAttributes<HTMLDivElement> {
+  children: FabGroupChild | FabGroupChild[];
+  trigger?: ButtonTrigger;
+  position?: FabPosition;
+}
+
+function FabGroup({ children, trigger = 'none', position = 'left', ...rest }: Props) {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const validChildren = Children.toArray(children).filter(isValidElement) as Array<
+    NonNullable<FabGroupChild>
+  >;
+
+  const FabGroupItems = validChildren.map((child) => {
+    return cloneElement(child, { type: 'icon' });
+  });
+
+  return (
+    <FABWrapper position={position}>
+      {trigger === 'none' ? (
+        <FABGroup isTriggered={false} {...rest}>
+          {FabGroupItems}
+        </FABGroup>
+      ) : (
+        <>
+          <Fab
+            type='circle'
+            onClick={() => trigger === 'click' && setIsOpen(!isOpen)}
+            onMouseEnter={() => trigger === 'hover' && setIsOpen(!isOpen)}
+            onMouseLeave={() => trigger === 'hover' && setIsOpen(!isOpen)}
+          />
+          <FABGroup isTriggered={true} isOpen={isOpen} {...rest}>
+            {FabGroupItems}
+          </FABGroup>
+        </>
+      )}
+    </FABWrapper>
+  );
+}
+
+export default FabGroup;
+
+const FABWrapper = styled.div<Pick<Props, 'position'>>`
+  display: flex;
+  position: fixed;
+  left: ${({ position }) => position === 'left' && '2em'};
+  right: ${({ position }) => position === 'right' && '2em'};
+  bottom: 2em;
+`;
+
+const FABGroup = styled.div<{ isTriggered: boolean; isOpen?: boolean }>`
+  display: flex;
+  background: rgba(0, 0, 0, ${({ isTriggered }) => (isTriggered ? 0.5 : 0.7)});
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  border-radius: 50px;
+  height: 55px;
+  width: fit-content;
+  padding: ${({ isTriggered }) => (isTriggered ? '0 30px 0 75px' : '0 30px')};
+  justify-content: center;
+  gap: 24px;
+  margin-left: ${({ isTriggered }) => isTriggered && '-55px'};
+  visibility: ${({ isOpen, isTriggered }) => isTriggered && (isOpen ? 'visible' : 'hidden')};
+`;

--- a/src/components/Fab/FabGroup.tsx
+++ b/src/components/Fab/FabGroup.tsx
@@ -9,23 +9,32 @@ import {
 } from 'react';
 import Fab from './Fab';
 import styled from 'styled-components';
+import { Props as FabProps } from './Fab';
 
 type FabGroupChild = ReactElement<ComponentProps<typeof Fab>> | null;
 
-export interface Props extends HTMLAttributes<HTMLDivElement> {
+export interface Props
+  extends HTMLAttributes<HTMLDivElement>,
+    Pick<FabProps, 'type' | 'iconName' | 'position'> {
   children: FabGroupChild | FabGroupChild[];
   trigger?: ButtonTrigger;
-  position?: FabPosition;
 }
 
-function FabGroup({ children, trigger = 'none', position = 'left', ...rest }: Props) {
+function FabGroup({
+  children,
+  trigger = 'none',
+  position = 'left',
+  type,
+  iconName,
+  ...rest
+}: Props) {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const validChildren = Children.toArray(children).filter(isValidElement) as Array<
     NonNullable<FabGroupChild>
   >;
 
   const FabGroupItems = validChildren.map((child) => {
-    return cloneElement(child, { type: 'icon' });
+    return cloneElement(child, { shape: 'icon', position: 'none' });
   });
 
   return (
@@ -37,7 +46,10 @@ function FabGroup({ children, trigger = 'none', position = 'left', ...rest }: Pr
       ) : (
         <>
           <Fab
-            type='circle'
+            shape='circle'
+            position='none'
+            type={type}
+            iconName={iconName}
             onClick={() => trigger === 'click' && setIsOpen(!isOpen)}
             onMouseEnter={() => trigger === 'hover' && setIsOpen(!isOpen)}
             onMouseLeave={() => trigger === 'hover' && setIsOpen(!isOpen)}
@@ -55,10 +67,10 @@ export default FabGroup;
 
 const FABWrapper = styled.div<Pick<Props, 'position'>>`
   display: flex;
-  position: fixed;
+  position: ${({ position }) => position !== 'none' && 'fixed'};
   left: ${({ position }) => position === 'left' && '2em'};
   right: ${({ position }) => position === 'right' && '2em'};
-  bottom: 2em;
+  bottom: ${({ position }) => position !== 'none' && '2em'};
 `;
 
 const FABGroup = styled.div<{ isTriggered: boolean; isOpen?: boolean }>`

--- a/src/components/Fab/Tooltip.tsx
+++ b/src/components/Fab/Tooltip.tsx
@@ -1,0 +1,33 @@
+import { HTMLAttributes } from 'react';
+import styled from 'styled-components';
+
+export interface Props extends HTMLAttributes<HTMLDivElement> {
+  isShown?: boolean;
+  text: string;
+}
+
+function Tooltip({ isShown = false, text, ...rest }: Props) {
+  return (
+    <TooltipContainer isShown={isShown} {...rest}>
+      {text}
+    </TooltipContainer>
+  );
+}
+
+export default Tooltip;
+
+const TooltipContainer = styled.div<{ isShown: boolean }>`
+  background: rgba(217, 217, 217, 0.8);
+  border-radius: 25px;
+  width: fit-content;
+  padding: 5px 21px;
+  font-weight: ${({ theme }) => theme.fontWeight.light};
+  font-size: ${({ theme }) => theme.typo.small};
+  color: ${({ theme }) => theme.colors.titleActive};
+  visibility: ${({ isShown }) => (isShown ? 'visible' : 'hidden')};
+  position: absolute;
+  top: 140%;
+  left: 50%;
+  transform: translateY(-50%) translateX(-50%);
+  width: max-content;
+`;

--- a/src/components/Fab/index.ts
+++ b/src/components/Fab/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Fab';

--- a/src/components/Fab/types.d.ts
+++ b/src/components/Fab/types.d.ts
@@ -1,5 +1,7 @@
 type ButtonTrigger = 'click' | 'hover' | 'none';
 
-type FabButtonType = 'circle' | 'icon';
+type FabButtonShape = 'circle' | 'icon';
 
-type FabPosition = 'left' | 'right';
+type FabButtonType = 'default' | 'primary';
+
+type FabPosition = 'left' | 'right' | 'none';

--- a/src/components/Fab/types.d.ts
+++ b/src/components/Fab/types.d.ts
@@ -1,0 +1,5 @@
+type ButtonTrigger = 'click' | 'hover' | 'none';
+
+type FabButtonType = 'circle' | 'icon';
+
+type FabPosition = 'left' | 'right';


### PR DESCRIPTION
## 💡 왜 PR을 하셨나요?

issue: #2 

## 🧑‍💻 작업 사항

<!-- 어떤 변경사항이 있는지, PR 타이틀과 동일하다면 Skip -->
- 관리자 계정 접근 시 좌측 하단에 띄워지는 Floating Action Button 컴포넌트 구현
- 단순 버튼만 존재하는 FAB와 버튼 클릭 시 메뉴가 열리는 FAB.Group 추가

## 🔗 링크

<!-- 관련된 대화가 이루어진 슬랙 링크 혹은 피그마 링크를 첨부. -->
<!-- - [프레이머](https://framer.com/projects/2--gSDcZoNKqU6dqCUQUYQe-53rEr?node=tQMWSSKqy)  -->

## 🐰 시급한 정도

🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다.
<!-- 🚨 긴급 : 선 어프루브 후 리뷰를 부탁드립니다. (리뷰는 추후 반영)  -->
<!-- 🐢 천천히 : 급하지 않습니다. -->

## 📖 참고 사항

<!-- 공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.  -->

<img width="212" alt="image" src="https://user-images.githubusercontent.com/68578916/236114786-6cd3d8e9-4143-4e71-8d8f-335e4d654557.png">

<img width="315" alt="image" src="https://user-images.githubusercontent.com/68578916/236114870-2d468e91-4150-44b6-9d40-d01af17e4f94.png">


<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->
사용 예시 코드
```ts
return (
  <div style={{ display: 'flex', flexDirection: 'column', gap: 30, padding: 30 }}>
      <Fab />
      <Fab.Group trigger='click' type='primary'>
        <Fab iconName='intro-poll' tooltip='Go to polls' />
        <Fab iconName='clipboard' tooltip='Copy channel link' />
        <Fab iconName='fullscreen' tooltip='Fullscreen' />
        <Fab iconName='disabled' tooltip='Disable participant Q&A' />
        <Fab iconName='door-back' tooltip='Back to main' />
      </Fab.Group>
  
      <Fab.Group position='right'>
        <Fab iconName='intro-poll' tooltip='Go to polls' />
        <Fab iconName='clipboard' tooltip='Copy channel link' />
        <Fab iconName='fullscreen' tooltip='Fullscreen' />
        <Fab iconName='disabled' tooltip='Disable participant Q&A' />
        <Fab iconName='door-back' tooltip='Back to main' />
      </Fab.Group>
    </div>
);
```
